### PR TITLE
Fix failure when build the tools/pkg-config & tools/mkimage with gcc 6.2

### DIFF
--- a/tools/mkimage/patches/1000-gcc6_compat.patch
+++ b/tools/mkimage/patches/1000-gcc6_compat.patch
@@ -1,0 +1,67 @@
+diff --git a/include/linux/compiler-gcc6.h b/include/linux/compiler-gcc6.h
+new file mode 100644
+index 0000000..ba064fa
+--- /dev/null
++++ b/include/linux/compiler-gcc6.h
+@@ -0,0 +1,59 @@
++#ifndef __LINUX_COMPILER_H
++#error "Please don't include <linux/compiler-gcc6.h> directly, include <linux/compiler.h> instead."
++#endif
++
++#define __used	__attribute__((__used__))
++#define __must_check	__attribute__((warn_unused_result))
++#define __compiler_offsetof(a, b)	__builtin_offsetof(a, b)
++
++/* Mark functions as cold. gcc will assume any path leading to a call
++ to them will be unlikely. This means a lot of manual unlikely()s
++ are unnecessary now for any paths leading to the usual suspects
++ like BUG(), printk(), panic() etc. [but let's keep them for now for
++ older compilers]
++
++ gcc also has a __attribute__((__hot__)) to move hot functions into
++ a special section, but I don't see any sense in this right now in
++ the kernel context */
++#define __cold	__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++
++/*
++ * Mark a position in code as unreachable. This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible __attribute__((externally_visible))
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ * http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#define __HAVE_BUILTIN_BSWAP16__
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
++
++#define KASAN_ABI_VERSION 4
+--
+2.1.0

--- a/tools/mkimage/patches/1001-fix_build-with-OpenSSL-1.1.x.patch
+++ b/tools/mkimage/patches/1001-fix_build-with-OpenSSL-1.1.x.patch
@@ -1,0 +1,86 @@
+diff --git a/lib/rsa/rsa-sign.c b/lib/rsa/rsa-sign.c
+index 8c6637e328..965fb00f95 100644
+--- a/lib/rsa/rsa-sign.c
++++ b/lib/rsa/rsa-sign.c
+@@ -20,6 +20,19 @@
+ #define HAVE_ERR_REMOVE_THREAD_STATE
+ #endif
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++void RSA_get0_key(const RSA *r,
++                 const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
++{
++   if (n != NULL)
++       *n = r->n;
++   if (e != NULL)
++       *e = r->e;
++   if (d != NULL)
++       *d = r->d;
++}
++#endif
++
+ static int rsa_err(const char *msg)
+ {
+ 	unsigned long sslErr = ERR_get_error();
+@@ -409,7 +422,11 @@ static int rsa_sign_with_key(RSA *rsa, struct checksum_algo *checksum_algo,
+ 		ret = rsa_err("Could not obtain signature");
+ 		goto err_sign;
+ 	}
+-	EVP_MD_CTX_cleanup(context);
++	#if OPENSSL_VERSION_NUMBER < 0x10100000L
++		EVP_MD_CTX_cleanup(context);
++	#else
++		EVP_MD_CTX_reset(context);
++	#endif
+ 	EVP_MD_CTX_destroy(context);
+ 	EVP_PKEY_free(key);
+ 
+@@ -479,6 +496,7 @@ static int rsa_get_exponent(RSA *key, uint64_t *e)
+ {
+ 	int ret;
+ 	BIGNUM *bn_te;
++	const BIGNUM *key_e;
+ 	uint64_t te;
+ 
+ 	ret = -EINVAL;
+@@ -487,17 +505,18 @@ static int rsa_get_exponent(RSA *key, uint64_t *e)
+ 	if (!e)
+ 		goto cleanup;
+ 
+-	if (BN_num_bits(key->e) > 64)
++	RSA_get0_key(key, NULL, &key_e, NULL);
++	if (BN_num_bits(key_e) > 64)
+ 		goto cleanup;
+ 
+-	*e = BN_get_word(key->e);
++	*e = BN_get_word(key_e);
+ 
+-	if (BN_num_bits(key->e) < 33) {
++	if (BN_num_bits(key_e) < 33) {
+ 		ret = 0;
+ 		goto cleanup;
+ 	}
+ 
+-	bn_te = BN_dup(key->e);
++	bn_te = BN_dup(key_e);
+ 	if (!bn_te)
+ 		goto cleanup;
+ 
+@@ -527,6 +546,7 @@ int rsa_get_params(RSA *key, uint64_t *exponent, uint32_t *n0_invp,
+ {
+ 	BIGNUM *big1, *big2, *big32, *big2_32;
+ 	BIGNUM *n, *r, *r_squared, *tmp;
++	const BIGNUM *key_n;
+ 	BN_CTX *bn_ctx = BN_CTX_new();
+ 	int ret = 0;
+ 
+@@ -548,7 +568,8 @@ int rsa_get_params(RSA *key, uint64_t *exponent, uint32_t *n0_invp,
+ 	if (0 != rsa_get_exponent(key, exponent))
+ 		ret = -1;
+ 
+-	if (!BN_copy(n, key->n) || !BN_set_word(big1, 1L) ||
++	RSA_get0_key(key, NULL, &key_n, NULL);
++	if (!BN_copy(n, key_n) || !BN_set_word(big1, 1L) ||
+ 	    !BN_set_word(big2, 2L) || !BN_set_word(big32, 32L))
+ 		ret = -1;
+ 

--- a/tools/pkg-config/patches/1000-fix_format_not_a_string_literal.patch
+++ b/tools/pkg-config/patches/1000-fix_format_not_a_string_literal.patch
@@ -1,0 +1,13 @@
+--- a/glib/glib/gdate.c
++++ b/glib/glib/gdate.c
+@@ -2494,7 +2494,10 @@ g_date_strftime (gchar       *s,
+        * recognize whether strftime actually failed or just returned "".
+        */
+       tmpbuf[0] = '\1';
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+       tmplen = strftime (tmpbuf, tmpbufsize, locale_format, &tm);
++#pragma GCC diagnostic pop
+ 
+       if (tmplen == 0 && tmpbuf[0] != '\0')
+         {


### PR DESCRIPTION
Fix failure when build the tools/pkg-config & tools/mkimage with gcc 6.2
修复用gcc6.2编译 tools/pkg-config & tools/mkimage时报错